### PR TITLE
borrow 기능을 사용하는 네트워크를 Sepolia testnet에서 Ethereum mainnet으로 변경

### DIFF
--- a/liquityComponentBorrow.jsx
+++ b/liquityComponentBorrow.jsx
@@ -4,18 +4,22 @@ State.init({
   coll: 0,
   borrow: 0,
   borrowingFee: 0,
-  totalcoll: 200,
+  totalcoll: 0,
   collateralRatio: 0,
-  liquidationReserve: 200,
+  liquidationReserve: 0,
   complete: false,
   loading: false,
   msg: "",
+  borrowRate: 0,
   address: undefined,
   chainId: undefined,
   balance: undefined,
   price: 0,
   isOpenTrove: undefined,
+  isRecoveryMode: undefined,
   isBlocked: true,
+  isGasAllocated: false,
+  isBorrowingRate: false,
 });
 
 const setcoll = (depositChangeEvent) => {
@@ -34,10 +38,11 @@ const setcoll = (depositChangeEvent) => {
 };
 
 const setBorrow = (borrowChangeEvent) => {
-  const { coll, liquidationReserve } = state;
+  const { coll, liquidationReserve, borrowRate, isRecoveryMode } = state;
   const value = borrowChangeEvent.target.value.replace(/[^.0-9]/g, "");
   const borrow = Number(value);
-  const borrowingFee = (borrow * 0.5) / 100;
+  const borrowingFee =
+    isRecoveryMode === true ? 0 : (borrow * borrowRate) / 100;
   const totalcoll =
     borrow + Number(borrowingFee.toFixed(2)) + liquidationReserve;
   const collateralRatio = ((coll * state.price) / Number(totalcoll)) * 100;
@@ -53,7 +58,7 @@ const setBorrow = (borrowChangeEvent) => {
 };
 
 const validateTrove = () => {
-  const { coll, borrow, totalcoll, balance } = state;
+  const { coll, borrow, totalcoll, balance, isRecoveryMode } = state;
 
   if (borrow < 1800) {
     State.update({
@@ -64,12 +69,23 @@ const validateTrove = () => {
   }
 
   const collateralRatio = ((coll * state.price) / Number(totalcoll)) * 100;
-  if (collateralRatio < 110) {
-    State.update({
-      msg: "Collateral ratio must be at least 110%",
-      isBlocked: true,
-    });
-    return;
+
+  if (isRecoveryMode === true) {
+    if (collateralRatio < 150) {
+      State.update({
+        msg: "Collateral ratio must be at least 150%",
+        isBlocked: true,
+      });
+      return;
+    }
+  } else {
+    if (collateralRatio < 110) {
+      State.update({
+        msg: "Collateral ratio must be at least 110%",
+        isBlocked: true,
+      });
+      return;
+    }
   }
 
   if (coll > Number(balance)) {
@@ -83,71 +99,217 @@ const validateTrove = () => {
   State.update({ msg: "", isBlocked: false });
 };
 
-const borrowerOperationAddress = "0xD69fC8928D4F3229341cb431263F1EBd87B1ade8";
+const borrowerOperationAddress = "0x24179CD81c9e782A4096035f7eC97fB8B783e007";
+const borrowerOperationABI = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "_maxFeePercentage", type: "uint256" },
+      { internalType: "uint256", name: "_LUSDAmount", type: "uint256" },
+      { internalType: "address", name: "_upperHint", type: "address" },
+      { internalType: "address", name: "_lowerHint", type: "address" },
+    ],
+    name: "openTrove",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+];
 
-const troveManagerAddress = "0x0ECDF34731eE8Dd46caa99a1AAE173beD1B32c67";
+const troveManagerAddress = "0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2";
 
-const borrowerOperationAbi = fetch(
-  "https://api-sepolia.etherscan.io/api?module=contract&action=getabi&address=0xcb306e2509ca52872c2d04160F3c1fa7bc013064"
-);
+const troveManagerABI = [
+  {
+    inputs: [{ internalType: "address", name: "_borrower", type: "address" }],
+    name: "getTroveStatus",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_price", type: "uint256" }],
+    name: "getTCR",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "LUSD_GAS_COMPENSATION",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_LUSDDebt", type: "uint256" }],
+    name: "getBorrowingFeeWithDecay",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getBorrowingRateWithDecay",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [{ internalType: "uint256", name: "_price", type: "uint256" }],
+    name: "checkRecoveryMode",
+    outputs: [{ internalType: "bool", name: "", type: "bool" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
 
-const troveManagerAbi = fetch(
-  "https://raw.githubusercontent.com/IDKNWHORU/liquity-sepolia/main/trove-manager-abi.json"
-);
+const priceFeedAddress = "0x4c517D4e2C851CA76d7eC94B805269Df0f2201De";
+const priceFeedABI = [
+  {
+    inputs: [],
+    name: "lastGoodPrice",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+];
 
-const priceFeedAddress = "0x07dD4Ce17De84bA13Fc154A7FdB46fC362a41E2C";
-const priceFeedAbi = fetch(
-  "https://raw.githubusercontent.com/IDKNWHORU/liquity-sepolia/main/price-feed-abi.json"
-);
+const sortedtrovesAddress = "0x8FdD3fbFEb32b28fb73555518f8b361bCeA741A6";
+const sortedtrovesABI = [
+  {
+    inputs: [],
+    name: "getSize",
+    outputs: [{ internalType: "uint256", name: "", type: "uint256" }],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      { internalType: "uint256", name: "_NICR", type: "uint256" },
+      { internalType: "address", name: "_prevId", type: "address" },
+      { internalType: "address", name: "_nextId", type: "address" },
+    ],
+    name: "findInsertPosition",
+    outputs: [
+      { internalType: "address", name: "", type: "address" },
+      { internalType: "address", name: "", type: "address" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];
 
-const openTrove = () => {
+const hintHelpersAddress = "0xE84251b93D9524E0d2e621Ba7dc7cb3579F997C0";
+const hintHelpersABI = [
+  {
+    inputs: [
+      { internalType: "uint256", name: "_CR", type: "uint256" },
+      { internalType: "uint256", name: "_numTrials", type: "uint256" },
+      { internalType: "uint256", name: "_inputRandomSeed", type: "uint256" },
+    ],
+    name: "getApproxHint",
+    outputs: [
+      { internalType: "address", name: "hintAddress", type: "address" },
+      { internalType: "uint256", name: "diff", type: "uint256" },
+      { internalType: "uint256", name: "latestRandomSeed", type: "uint256" },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+];
+
+const openTrove = async () => {
   if (state.complete) {
     State.update({ complete: false, hash: null });
   }
+
   const borrowerOperationContract = new ethers.Contract(
     borrowerOperationAddress,
-    borrowerOperationAbi.body.result,
+    borrowerOperationABI,
     Ethers.provider().getSigner()
   );
 
-  borrowerOperationContract
-    .openTrove(
-      ethers.BigNumber.from(5000000000000000),
-      ethers.BigNumber.from(state.borrow * 100)
-        .mul("10000000000000000")
-        .toString(),
-      // ethers.BigNumber.from((state.borrow * 10000000000000000).toString()),
-      "0x1Bc65296aa95A0fD41d6A8AEb34C49665c6de81d",
-      "0x1Bc65296aa95A0fD41d6A8AEb34C49665c6de81d",
-      {
-        value: ethers.BigNumber.from(
-          (state.coll * 1000000000000000000).toString()
-        ),
-        // gasPrice: state.gasPrice,
-        // gasLimit: 25000000,
-      }
-    )
-    .then((transactionHash) => {
-      State.update({
-        loading: true,
-        hash: transactionHash.hash,
-        borrow: 0,
-        displayBorrow: "",
-        coll: 0,
-        displayColl: "",
-        borrowingFee: 0,
-        totalcoll: 200,
-        collateralRatio: 0,
-        liquidationReserve: 200,
+  const sortedTroveContract = new ethers.Contract(
+    sortedtrovesAddress,
+    sortedtrovesABI,
+    Ethers.provider().getSigner()
+  );
+
+  const hintHelpersContract = new ethers.Contract(
+    hintHelpersAddress,
+    hintHelpersABI,
+    Ethers.provider().getSigner()
+  );
+
+  const LUSDAmount = ethers.BigNumber.from(
+    ethers.utils.parseEther(state.borrow.toString())
+  );
+
+  const expectedDebt = ethers.BigNumber.from(
+    ethers.utils.parseEther(state.totalcoll.toString())
+  );
+
+  const _1e20 = ethers.BigNumber.from(ethers.utils.parseEther("100"));
+
+  const ETHColl = ethers.BigNumber.from(
+    ethers.utils.parseEther(state.coll.toString())
+  );
+
+  const NICR = ETHColl.mul(_1e20).div(expectedDebt);
+
+  sortedTroveContract.getSize().then((numTroves) => {
+    const _numTrials = numTroves.mul(ethers.BigNumber.from("15"));
+
+    hintHelpersContract
+      .getApproxHint(NICR, _numTrials, 42)
+      .then((approxHintRes) => {
+        const approxHint = approxHintRes[0];
+
+        sortedTroveContract
+          .findInsertPosition(NICR, approxHint, approxHint)
+          .then((hintRes) => {
+            const upperHint = hintRes[0];
+            const lowerHint = hintRes[1];
+
+            borrowerOperationContract
+              .openTrove(
+                ethers.BigNumber.from(ethers.utils.parseEther("0.005")),
+                LUSDAmount,
+                upperHint,
+                lowerHint,
+                {
+                  value: ETHColl,
+                }
+              )
+              .then((transactionHash) => {
+                State.update({
+                  loading: true,
+                  hash: transactionHash.hash,
+                  borrow: 0,
+                  displayBorrow: "",
+                  coll: 0,
+                  displayColl: "",
+                  borrowingFee: 0,
+                  totalcoll: state.liquidationReserve,
+                  collateralRatio: 0,
+                  liquidationReserve: state.liquidationReserve,
+                });
+              });
+          });
       });
-    });
+  });
 };
 
 if (Ethers.provider()) {
   const signer = Ethers.provider().getSigner();
   signer.getAddress().then((address) => {
     State.update({ address });
-    if (state.chainId === 11155111) {
+    if (state.chainId === 1) {
+      const troveManagerContract = new ethers.Contract(
+        troveManagerAddress,
+        troveManagerABI,
+        Ethers.provider().getSigner()
+      );
+
       if (state.balance === undefined) {
         Ethers.provider()
           .getBalance(address)
@@ -159,16 +321,40 @@ if (Ethers.provider()) {
       }
 
       if (state.isOpenTrove === undefined) {
-        const troveManagerContract = new ethers.Contract(
-          troveManagerAddress,
-          troveManagerAbi.body,
-          Ethers.provider().getSigner()
-        );
-
         troveManagerContract.getTroveStatus(address).then((res) => {
           const isOpenTrove = ethers.utils.formatEther(res).includes("1");
           State.update({ isOpenTrove });
         });
+      }
+
+      if (state.isGasAllocated === false) {
+        troveManagerContract
+          .LUSD_GAS_COMPENSATION()
+          .then((liquidationReserveRes) => {
+            const liquidationReserve = Number(
+              ethers.utils.formatEther(liquidationReserveRes)
+            );
+
+            State.update({
+              isGasAllocated: true,
+              totalcoll: liquidationReserve,
+              liquidationReserve: liquidationReserve,
+            });
+          });
+      }
+
+      if (state.isBorrowingRate === false) {
+        troveManagerContract
+          .getBorrowingRateWithDecay()
+          .then((borrowingRateRes) => {
+            State.update({
+              isBorrowingRate: true,
+              borrowRate:
+                Number(
+                  ethers.utils.formatEther(borrowingRateRes).substring(0, 6)
+                ) * 100,
+            });
+          });
       }
     }
   });
@@ -184,16 +370,17 @@ if (Ethers.provider()) {
   if (state.price === 0) {
     const priceFeedContract = new ethers.Contract(
       priceFeedAddress,
-      priceFeedAbi.body,
-      Ethers.provider().getSigner()
-    );
-    const troveManagerContract = new ethers.Contract(
-      troveManagerAddress,
-      troveManagerAbi.body,
+      priceFeedABI,
       Ethers.provider().getSigner()
     );
 
-    priceFeedContract.getPrice().then((priceRes) => {
+    const troveManagerContract = new ethers.Contract(
+      troveManagerAddress,
+      troveManagerABI,
+      Ethers.provider().getSigner()
+    );
+
+    priceFeedContract.lastGoodPrice().then((priceRes) => {
       const price = Number(ethers.utils.formatEther(priceRes));
 
       State.update({ price });
@@ -202,6 +389,12 @@ if (Ethers.provider()) {
 
         State.update({ tcr });
       });
+
+      troveManagerContract
+        .checkRecoveryMode(ethers.BigNumber.from(priceRes))
+        .then((isRecoveryMode) => {
+          State.update({ isRecoveryMode: isRecoveryMode });
+        });
     });
   }
 }
@@ -322,9 +515,7 @@ return (
         <input
           type="text"
           placeholder="0.0000 ETH"
-          disabled={
-            !state.address || state.isOpenTrove || state.chainId !== 11155111
-          }
+          disabled={!state.address || state.isOpenTrove || state.chainId !== 1}
           onChange={setcoll}
           value={state.displayColl}
         ></input>
@@ -336,9 +527,7 @@ return (
         <input
           type="text"
           placeholder="0.0000 LUSD"
-          disabled={
-            !state.address || state.isOpenTrove || state.chainId !== 11155111
-          }
+          disabled={!state.address || state.isOpenTrove || state.chainId !== 1}
           onChange={setBorrow}
           value={state.displayBorrow}
         />
@@ -357,7 +546,10 @@ return (
         <div className="detail-info-label">Borrowing Fee</div>
         <div className="detail-info-value">
           <span className="">{state.borrowingFee.toFixed(2)}</span>{" "}
-          <span className="info-unit">LUSD (0.50%)</span>
+          <span className="info-unit">
+            LUSD (
+            {state.isRecoveryMode === true ? 0 : state.borrowRate.toFixed(2)}%)
+          </span>
         </div>
       </div>
 
@@ -391,8 +583,8 @@ return (
           disabled={state.isBlocked}
           onClick={openTrove}
         >
-          {Ethers.provider() && state.chainId !== 11155111
-            ? "Change network to Sepolia"
+          {Ethers.provider() && state.chainId !== 1
+            ? "Change network to Ethereum"
             : state.isOpenTrove === true
             ? "You already have active Trove"
             : state.loading


### PR DESCRIPTION
# 현재 작업한 기능
- [x] liquidationReserve를 LUSD_GAS_COMPENSATION 함수의 반환 값을 할당하도록 변경
- [X] borrowRate를 getBorrowingRateWithDecay 함수의 반환 값을 할당하도록 변경
- [X] isRecoveryMode를 체크하는 기능 추가
- [X] borrowFee를 recovery mode일 경우와 아닐 경우 계산하는 방법 추가
- [X] collateralRatio 유효성 검사할 때 recovery mode일 경우와 아닐 경우 방법 추가
- [X] 컨트랙트의 주소를 Sepoila testnet에서 Ethereum mainnet으로 변경
- [X] 컨트랙트의 ABI 정보를 소스 코드 내에 작성
- [X] openTrove 함수 실행하기 전 upperHint, lowerHint의 값을 가져오는 기능 추가
- [X] ETH 값을 가져오는 함수를 getPrice 함수에서 lastGoodPrice 함수로 변경

@Gwanghyun-Jeon  누락된 작업이 있으면 코멘트 추가해 줘~